### PR TITLE
Backfill missing lab metadata (7 files)

### DIFF
--- a/Instructions/Labs/LAB_00_Setup your environment.md
+++ b/Instructions/Labs/LAB_00_Setup your environment.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Lab 0: Setup your environment and software'
-    module: 'Learning Path 00: Set up your environment'
+  title: 'Lab 0: Setup your environment and software'
+  module: 'Learning Path 00: Set up your environment'
+  description: Setup your environment and software ===================================
+  duration: 32 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Lab: Setup your environment and software
 # Student lab manual

--- a/Instructions/Labs/LAB_01_Create_extension_containing_table.md
+++ b/Instructions/Labs/LAB_01_Create_extension_containing_table.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 01: Create an extension containing a: table, table extension, pages, page extension.'
-    module: 'Module 4: Install, develop, and deploy for the Business Central application'
+  title: 'Lab 01: Create an extension containing a: table, table extension, pages,
+    page extension.'
+  module: 'Module 4: Install, develop, and deploy for the Business Central application'
+  description: 'Lab 01 - Create an extension containing a: table, table extension,
+    pages, page extension. ========================================================================================='
+  duration: 124 minutes
+  level: 100
+  islab: true
 ---
 
 Lab 01 - Create an extension containing a: table, table extension, pages, page extension.

--- a/Instructions/Labs/LAB_02_Implement_installation_and_upgrade_code_extension.md
+++ b/Instructions/Labs/LAB_02_Implement_installation_and_upgrade_code_extension.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 02: Implement installation and upgrade code in an extension'
-    module: 'Module 4: AL Objects'
+  title: 'Lab 02: Implement installation and upgrade code in an extension'
+  module: 'Module 4: AL Objects'
+  description: Lab 02 – Implement installation and upgrade code in an extension. =================================================================
+  duration: 92 minutes
+  level: 100
+  islab: true
 ---
 
 Lab 02 – Implement installation and upgrade code in an extension.

--- a/Instructions/Labs/LAB_03_Add_a_Rolecenter_and_Profile.md
+++ b/Instructions/Labs/LAB_03_Add_a_Rolecenter_and_Profile.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 03: Add a Rolecenter and Profile'
-    module: 'Module 5: AL Objects'
+  title: 'Lab 03: Add a Rolecenter and Profile'
+  module: 'Module 5: AL Objects'
+  description: Lab 03 – Add a Rolecenter and Profile =====================================
+  duration: 62 minutes
+  level: 200
+  islab: true
 ---
 
 Lab 03 – Add a Rolecenter and Profile

--- a/Instructions/Labs/LAB_04_Add_a_column_and_layout_to_base_report.md
+++ b/Instructions/Labs/LAB_04_Add_a_column_and_layout_to_base_report.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 04: Add a column and layout to a base report'
-    module: 'Module 4: AL Objects'
+  title: 'Lab 04: Add a column and layout to a base report'
+  module: 'Module 4: AL Objects'
+  description: Lab 04 – Add a column and layout to a base report. ==================================================
+  duration: 88 minutes
+  level: 100
+  islab: true
 ---
 
 Lab 04 – Add a column and layout to a base report.

--- a/Instructions/Labs/LAB_05_Develop_Custom_API_pages_and _queries.md
+++ b/Instructions/Labs/LAB_05_Develop_Custom_API_pages_and _queries.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 05: Develop custom API pages and queries'
-    module: 'Module 6: Dev Tools'
+  title: 'Lab 05: Develop custom API pages and queries'
+  module: 'Module 6: Dev Tools'
+  description: Lab 05 – Develop custom API pages and queries. ==============================================
+  duration: 56 minutes
+  level: 200
+  islab: true
 ---
 
 Lab 05 – Develop custom API pages and queries.

--- a/Instructions/Labs/LAB_06_Setup_source_control_Git_in_an_extension.md
+++ b/Instructions/Labs/LAB_06_Setup_source_control_Git_in_an_extension.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 05: Develop custom API pages and queries'
-    module: 'Module 6: Dev Tools'
+  title: 'Lab 05: Develop custom API pages and queries'
+  module: 'Module 6: Dev Tools'
+  description: Lab 06 – Setup source control, Git, in an extension. ====================================================
+  duration: 38 minutes
+  level: 200
+  islab: true
 ---
 
 Lab 06 – Setup source control, Git, in an extension.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 7

- `Instructions/Labs/LAB_00_Setup your environment.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_01_Create_extension_containing_table.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_02_Implement_installation_and_upgrade_code_extension.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_03_Add_a_Rolecenter_and_Profile.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_04_Add_a_column_and_layout_to_base_report.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_05_Develop_Custom_API_pages_and _queries.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_06_Setup_source_control_Git_in_an_extension.md` (description,duration,level,islab)
